### PR TITLE
Cleanup namespace handling in tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,6 +17,8 @@ jobs:
                       env: py310
                     - python: "3.11"
                       env: py311
+                    - python: "3.11"
+                      env: py311-namespace
                     - python: "3.12"
                       env: py312
                     - python: pypy-3.10

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+docs/license.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include docs/conf.py
 include docs/test_server.ini
 include regen-docs
 include tox.ini
+include LICENSE
 recursive-exclude docs/_build/_sources *
 recursive-include docs/_build *.html
 recursive-include tests *.txt *.py *.cgi *.html

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,7 @@
 """Tests for Paste"""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pkg_resources

--- a/tests/cgiapp_data/form.cgi
+++ b/tests/cgiapp_data/form.cgi
@@ -4,10 +4,19 @@ print('Content-type: text/plain')
 print('')
 
 import sys
+import warnings
 from os.path import dirname
 
 base_dir = dirname(dirname(dirname(__file__)))
 sys.path.insert(0, base_dir)
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=DeprecationWarning)
+    try:
+        import pkg_resources
+    except ImportError:
+        # Ignore
+        pass
 
 from paste.util.field_storage import FieldStorage
 
@@ -52,7 +61,7 @@ class FormFieldStorage(FieldStorage):
         return False
 
 
-form = FieldStorage()
+form = FormFieldStorage()
 
 print('Filename:', form['up'].filename)
 print('Name:', form['name'].value)

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,29 @@
 [tox]
-envlist = py{36, 37, 38, 39, 310, 311, 312, py}
+envlist = py{36, 37, 38, 39, 310, 311, 312, py},py311-namespace
+skipsdist = True
+
+[base]
+deps =
+    pytest
+    setuptools
 
 [testenv]
 # For performance, but also for using "source" with coveragepy (https://github.com/nedbat/coveragepy/issues/268).
 usedevelop = True
 deps =
-    pytest
+    {[base]deps}
     coverage: coverage
     coverage: pytest-cov
 setenv =
     coverage: PYTEST_ADDOPTS=--cov --cov-report=term-missing
 commands =
-    pytest {posargs}
+    python -m pytest {posargs}
+
+# Test an environment where paste, pastedeploy and pastescript are already
+# installed.
+[testenv:py311-namespace]
+deps =
+    {[base]deps}
+    Paste==3.9.0
+    PasteDeploy
+    pastescript

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py{36, 37, 38, 39, 310, 311, 312, py},py311-namespace
-skipsdist = True
 
 [base]
 deps =


### PR DESCRIPTION
When we did a lot of recent Python2-isms cleanup recently it broke some tests when run in an environment where a previous version of paste, or one of the consumers of its namespace package, were already installed.

This was probably done to quiet warnings. However, it hides issues with complex environments.

In addition to fixing the problem, this change adds a tox test environment that should cause a failure if we introduce the error again.

Fixes #99